### PR TITLE
Fix for 'user cannot create a group'

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Groups core extension',
     'description' => 'TAO Groups extension',
     'license' => 'GPL-2.0',
-    'version' => '6.0.0',
+    'version' => '6.0.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoTestTaker' => '>=4.0.0',

--- a/models/update/Updater.php
+++ b/models/update/Updater.php
@@ -77,6 +77,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.0.1');
         }
 
-        $this->skip('3.0.1','6.0.0');
+        $this->skip('3.0.1','6.0.1');
     }
 }

--- a/views/js/provider/group.js
+++ b/views/js/provider/group.js
@@ -18,7 +18,7 @@
  * @author Alexander Zagovorichev <zagovorichev@1pt.com>
  */
 
-define(['jquery', 'lodash', 'i18n', 'util/url', 'core/promise'], function ($, _, __, urlUtil, Promise) {
+define(['jquery', 'lodash', 'i18n', 'util/url', 'core/promise', 'core/request'], function ($, _, __, urlUtil, Promise, coreRequest) {
     'use strict';
 
     /**
@@ -55,17 +55,18 @@ define(['jquery', 'lodash', 'i18n', 'util/url', 'core/promise'], function ($, _,
                 config = _.defaults(config || {}, _defaults);
 
                 return new Promise(function(resolve, reject){
-
-                    $.ajax({
-                        url: urlUtil.route('addInstance', 'Groups', 'taoGroups'),
-                        type: 'post',
-                        data: config,
-                        dataType: 'json'
-                    })
-                        .done(function (group) {
+                        coreRequest({
+                            url: urlUtil.route('addInstance', 'Groups', 'taoGroups'),
+                            method: 'POST',
+                            type: 'post',
+                            data: config,
+                            dataType: 'json',
+                            noToken: false
+                        })
+                        .then(function (group) {
                             resolve(group);
                         })
-                        .fail(function () {
+                        .catch(function () {
                             reject(new Error(__('Unable to create new group')));
                         });
                 });

--- a/views/js/provider/group.js
+++ b/views/js/provider/group.js
@@ -58,10 +58,7 @@ define(['jquery', 'lodash', 'i18n', 'util/url', 'core/promise', 'core/request'],
                         coreRequest({
                             url: urlUtil.route('addInstance', 'Groups', 'taoGroups'),
                             method: 'POST',
-                            type: 'post',
-                            data: config,
-                            dataType: 'json',
-                            noToken: false
+                            data: config
                         })
                         .then(function (group) {
                             resolve(group);

--- a/views/js/provider/group.js
+++ b/views/js/provider/group.js
@@ -58,7 +58,8 @@ define(['jquery', 'lodash', 'i18n', 'util/url', 'core/promise', 'core/request'],
                         coreRequest({
                             url: urlUtil.route('addInstance', 'Groups', 'taoGroups'),
                             method: 'POST',
-                            data: config
+                            data: config,
+                            dataType: 'json',
                         })
                         .then(function (group) {
                             resolve(group);
@@ -87,6 +88,7 @@ define(['jquery', 'lodash', 'i18n', 'util/url', 'core/promise', 'core/request'],
                         url: urlUtil.route('delete', 'Groups', 'taoGroups'),
                         method: 'POST',
                         data: {uri: uri},
+                        dataType: 'json',
                     })
                     .then(function (response) {
                         resolve(response);

--- a/views/js/provider/group.js
+++ b/views/js/provider/group.js
@@ -83,18 +83,17 @@ define(['jquery', 'lodash', 'i18n', 'util/url', 'core/promise', 'core/request'],
                         return reject(new TypeError(__('Group uri is not valid')));
                     }
 
-                    $.ajax({
+                    coreRequest({
                         url: urlUtil.route('delete', 'Groups', 'taoGroups'),
-                        type: 'post',
+                        method: 'POST',
                         data: {uri: uri},
-                        dataType: 'json'
                     })
-                        .done(function (response) {
-                            resolve(response);
-                        })
-                        .fail(function () {
-                            reject(new Error(__('Unable to delete group')));
-                        });
+                    .then(function (response) {
+                        resolve(response);
+                    })
+                    .catch(function () {
+                        reject(new Error(__('Unable to delete group')));
+                    });
                 });
             }
         };


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8316

The bug was that there was only AJAX call instead of a Form so a token wasn't provided (no `X-CSRF-Token` parameter) and as a result, we had `403 Unable to process your request`. 

Now `coreRequest` is used and it catches the token from the global context, the token is passed to the BE as a request parameter. 