### PR TITLE
TAO-8629 - The class and integration tests are refactored

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Groups core extension',
     'description' => 'TAO Groups extension',
     'license' => 'GPL-2.0',
-    'version' => '6.1.0',
+    'version' => '6.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoTestTaker' => '>=4.0.0',

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -28,6 +28,7 @@ use \core_kernel_classes_Resource;
 use \tao_models_classes_ClassService;
 use oat\taoTestTaker\models\TestTakerService;
 use oat\oatbox\user\User;
+use oat\tao\model\OntologyClassService;
 
 /**
  * Service methods to manage the Groups business models using the RDF API.
@@ -37,8 +38,7 @@ use oat\oatbox\user\User;
  * @package taoGroups
  
  */
-class GroupsService
-    extends tao_models_classes_ClassService
+class GroupsService extends OntologyClassService
 {
     const CLASS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#Group';
 
@@ -53,7 +53,7 @@ class GroupsService
      */
     public function getRootClass()
     {
-        return new core_kernel_classes_Class(self::CLASS_URI);
+        return $this->getClass(self::CLASS_URI);
     }
 
     /**

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -25,7 +25,6 @@ namespace oat\taoGroups\models;
 use \core_kernel_classes_Class;
 use \core_kernel_classes_Property;
 use \core_kernel_classes_Resource;
-use \tao_models_classes_ClassService;
 use oat\taoTestTaker\models\TestTakerService;
 use oat\oatbox\user\User;
 use oat\tao\model\OntologyClassService;
@@ -121,7 +120,8 @@ class GroupsService extends OntologyClassService
      * @param core_kernel_classes_Resource $group
      * @return boolean
      */
-    public function addUser($userUri, core_kernel_classes_Resource $group) {
+    public function addUser($userUri, core_kernel_classes_Resource $group)
+    {
         $user = new \core_kernel_classes_Resource($userUri);
         return $user->setPropertyValue(new core_kernel_classes_Property(self::PROPERTY_MEMBERS_URI), $group);
     }
@@ -133,7 +133,8 @@ class GroupsService extends OntologyClassService
      * @param core_kernel_classes_Resource $group
      * @return boolean
      */
-    public function removeUser($userUri, core_kernel_classes_Resource $group) {
+    public function removeUser($userUri, core_kernel_classes_Resource $group)
+    {
         $user = new \core_kernel_classes_Resource($userUri);
         return $user->removePropertyValue(new core_kernel_classes_Property(self::PROPERTY_MEMBERS_URI), $group);
     }

--- a/models/update/Updater.php
+++ b/models/update/Updater.php
@@ -77,6 +77,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.0.1');
         }
 
-        $this->skip('3.0.1','6.1.0');
+        $this->skip('3.0.1','6.1.1');
     }
 }

--- a/test/integration/GroupsTest.php
+++ b/test/integration/GroupsTest.php
@@ -41,40 +41,43 @@ use oat\tao\test\TaoPhpUnitTestRunner;
  
  */
 class GroupsTest extends TaoPhpUnitTestRunner {
-	
-	/**
-	 * @var GroupsService
-	 */
-	protected $groupsService = null;
-	
-	protected $subjectsService = null;
 
-	/**
-	 * tests initialization
-	 */
-	public function setUp(){
+    /**
+     * @var GroupsService
+     */
+    protected $groupsService = null;
+
+    protected $subjectsService = null;
+
+    /**
+     * tests initialization
+     */
+    public function setUp()
+    {
         TaoPhpUnitTestRunner::initTest();
-		$this->subjectsService = new TestTakerService();
-		$this->groupsService = new GroupsService();
-	}
+        $this->subjectsService = new TestTakerService();
+        $this->groupsService = new GroupsService();
+    }
 
-	/**
-	 * Test the user service implementation
-	 * @see tao_models_classes_ServiceFactory::get
-	 * @see oat\taoGroups\models\GroupsService::__construct
-	 */
-	public function testService(){
-		$this->assertIsA($this->subjectsService, '\tao_models_classes_Service');
-		$this->assertIsA($this->groupsService, 'oat\taoGroups\models\GroupsService');
-	}
+    /**
+     * Test the user service implementation
+     * @see tao_models_classes_ServiceFactory::get
+     * @see oat\taoGroups\models\GroupsService::__construct
+     */
+    public function testService()
+    {
+        $this->assertIsA($this->subjectsService, '\tao_models_classes_Service');
+        $this->assertIsA($this->groupsService, 'oat\taoGroups\models\GroupsService');
+    }
 
     /**
 	 * @return \core_kernel_classes_Class|null
      */
-    public function testGroup() {
-		$groupClass = $this->groupsService->getRootClass();
-		$this->assertIsA($groupClass, 'core_kernel_classes_Class');
-		$this->assertEquals(GroupsService::CLASS_URI, $groupClass->getUri());
+    public function testGroup()
+    {
+        $groupClass = $this->groupsService->getRootClass();
+        $this->assertIsA($groupClass, 'core_kernel_classes_Class');
+        $this->assertEquals(GroupsService::CLASS_URI, $groupClass->getUri());
 
         return $groupClass;
     }
@@ -84,11 +87,12 @@ class GroupsTest extends TaoPhpUnitTestRunner {
      * @param $group
      * @return \core_kernel_classes_Class
      */
-    public function testSubGroup($groupClass) {
-		$subGroupLabel = 'subGroup class';
-		$subGroup = $this->groupsService->createSubClass($groupClass, $subGroupLabel);
-		$this->assertIsA($subGroup, 'core_kernel_classes_Class');
-		$this->assertEquals($subGroupLabel, $subGroup->getLabel());
+    public function testSubGroup($groupClass)
+    {
+        $subGroupLabel = 'subGroup class';
+        $subGroup = $this->groupsService->createSubClass($groupClass, $subGroupLabel);
+        $this->assertIsA($subGroup, 'core_kernel_classes_Class');
+        $this->assertEquals($subGroupLabel, $subGroup->getLabel());
 
         $this->assertTrue($this->groupsService->isGroupClass($subGroup));
 
@@ -101,11 +105,12 @@ class GroupsTest extends TaoPhpUnitTestRunner {
      * @param $group
      * @return \core_kernel_classes_Resource
      */
-    public function testGroupInstance($groupClass) {
-		$groupInstanceLabel = 'group instance';
-		$groupInstance = $this->groupsService->createInstance($groupClass, $groupInstanceLabel);
-		$this->assertIsA($groupInstance, 'core_kernel_classes_Resource');
-		$this->assertEquals($groupInstanceLabel, $groupInstance->getLabel());
+    public function testGroupInstance($groupClass)
+    {
+        $groupInstanceLabel = 'group instance';
+        $groupInstance = $this->groupsService->createInstance($groupClass, $groupInstanceLabel);
+        $this->assertIsA($groupInstance, 'core_kernel_classes_Resource');
+        $this->assertEquals($groupInstanceLabel, $groupInstance->getLabel());
 
         return $groupInstance;
     }
@@ -115,18 +120,19 @@ class GroupsTest extends TaoPhpUnitTestRunner {
      * @param $subGroup
      * @return \core_kernel_classes_Class
      */
-    public function testSubGroupInstance($subGroupClass) {
-		$subGroupInstanceLabel = 'subGroup instance';
-		$subGroupInstance = $this->groupsService->createInstance($subGroupClass);
-		
-		$subGroupInstance->removePropertyValues(new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL));
-		$subGroupInstance->setLabel($subGroupInstanceLabel);
-		$this->assertIsA($subGroupInstance, 'core_kernel_classes_Resource');
-		$this->assertEquals($subGroupInstanceLabel, $subGroupInstance->getLabel());
-		
-		$subGroupInstanceLabel2 = 'my sub group instance';
-		$subGroupInstance->setLabel($subGroupInstanceLabel2);
-		$this->assertEquals($subGroupInstanceLabel2, $subGroupInstance->getLabel());
+    public function testSubGroupInstance($subGroupClass)
+    {
+        $subGroupInstanceLabel = 'subGroup instance';
+        $subGroupInstance = $this->groupsService->createInstance($subGroupClass);
+
+        $subGroupInstance->removePropertyValues(new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL));
+        $subGroupInstance->setLabel($subGroupInstanceLabel);
+        $this->assertIsA($subGroupInstance, 'core_kernel_classes_Resource');
+        $this->assertEquals($subGroupInstanceLabel, $subGroupInstance->getLabel());
+
+        $subGroupInstanceLabel2 = 'my sub group instance';
+        $subGroupInstance->setLabel($subGroupInstanceLabel2);
+        $this->assertEquals($subGroupInstanceLabel2, $subGroupInstance->getLabel());
 
         return $subGroupInstance;
     }
@@ -135,64 +141,67 @@ class GroupsTest extends TaoPhpUnitTestRunner {
      * @depends testGroupInstance
      * @param $groupInstance
      */
-    public function testDeleteGroupInstance($groupInstance) {
-		$this->assertTrue($groupInstance->delete());
+    public function testDeleteGroupInstance($groupInstance)
+    {
+        $this->assertTrue($groupInstance->delete());
     }
 
     /**
      * @depends testSubGroupInstance
      * @param $subGroupInstance
      */
-    public function testDeleteSubGroupInstance($subGroupInstance) {
-		$this->assertTrue($subGroupInstance->delete());
+    public function testDeleteSubGroupInstance($subGroupInstance)
+    {
+        $this->assertTrue($subGroupInstance->delete());
     }
 
     /**
      * @depends testSubGroup
      * @param $subGroup
      */
-    public function testDeleteSubGroupClass($subGroup) {
-		$this->assertTrue($subGroup->delete());
+    public function testDeleteSubGroupClass($subGroup)
+    {
+        $this->assertTrue($subGroup->delete());
     }
 
     /**
      * 
      * @author Lionel Lecaque, lionel@taotesting.com
      */
-	public function testGetGroups(){
-	    $groupClass = new GroupsService();
-            $groupClass = $groupClass->getRootClass();
-	    $this->assertTrue($this->groupsService->isGroupClass($groupClass));
-	     
-	    $subject = $this->subjectsService->createInstance($this->subjectsService->getRootClass(),'testSubject');
-	    $oneGroup = $groupClass->createInstance('testGroupInstance');
-	    
-	    $this->groupsService->addUser($subject->getUri(), $oneGroup);
-	    $oneGroup2 = $groupClass->createInstance('testGroupInstance2');
-	    
-	    $subclass = $groupClass->createSubClass('testGroupSubclass');
-	    $oneGroup3 = $subclass->createInstance('testSubGroupInstance');
-	    $this->groupsService->addUser($subject->getUri(), $oneGroup3);
-	    
-	    $generisUser = new \core_kernel_users_GenerisUser($subject);
-	    $groups = $this->groupsService->getGroups($generisUser);
-	    
-	    $this->assertTrue(is_array($groups));
-	    $this->assertTrue(count($groups) == 2);
-	    array_walk($groups, function (&$group) {
-	    	$group = $group->getUri();
-	    });
-	    $this->assertContains($oneGroup->getUri(), $groups);
-	    $this->assertNotContains($oneGroup2->getUri(), $groups);
-	    $this->assertContains($oneGroup3->getUri(), $groups);
-	    
-	    $this->assertTrue($this->groupsService->deleteGroup($oneGroup));
-	    $this->assertTrue($this->groupsService->deleteGroup($oneGroup2));
-	    $this->assertTrue($this->groupsService->deleteGroup($oneGroup3));
-	    
-	    $this->assertTrue($this->groupsService->deleteClass($subclass));
+    public function testGetGroups()
+    {
+        $groupClass = $this->groupsService->getRootClass();
+        $this->assertTrue($this->groupsService->isGroupClass($groupClass));
 
-	    $subject->delete();
-	}
+        $subject = $this->subjectsService->createInstance($this->subjectsService->getRootClass(),'testSubject');
+        $oneGroup = $groupClass->createInstance('testGroupInstance');
+
+        $this->groupsService->addUser($subject->getUri(), $oneGroup);
+        $oneGroup2 = $groupClass->createInstance('testGroupInstance2');
+
+        $subclass = $groupClass->createSubClass('testGroupSubclass');
+        $oneGroup3 = $subclass->createInstance('testSubGroupInstance');
+        $this->groupsService->addUser($subject->getUri(), $oneGroup3);
+
+        $generisUser = new \core_kernel_users_GenerisUser($subject);
+        $groups = $this->groupsService->getGroups($generisUser);
+
+        $this->assertTrue(is_array($groups));
+        $this->assertTrue(count($groups) == 2);
+        array_walk($groups, function (&$group) {
+            $group = $group->getUri();
+        });
+        $this->assertContains($oneGroup->getUri(), $groups);
+        $this->assertNotContains($oneGroup2->getUri(), $groups);
+        $this->assertContains($oneGroup3->getUri(), $groups);
+
+        $this->assertTrue($this->groupsService->deleteGroup($oneGroup));
+        $this->assertTrue($this->groupsService->deleteGroup($oneGroup2));
+        $this->assertTrue($this->groupsService->deleteGroup($oneGroup3));
+
+        $this->assertTrue($this->groupsService->deleteClass($subclass));
+
+        $subject->delete();
+    }
 	
 }

--- a/test/integration/GroupsTest.php
+++ b/test/integration/GroupsTest.php
@@ -54,8 +54,8 @@ class GroupsTest extends TaoPhpUnitTestRunner {
 	 */
 	public function setUp(){
         TaoPhpUnitTestRunner::initTest();
-		$this->subjectsService = TestTakerService::singleton();
-		$this->groupsService = GroupsService::singleton();
+		$this->subjectsService = new TestTakerService();
+		$this->groupsService = new GroupsService();
 	}
 
 	/**
@@ -160,7 +160,8 @@ class GroupsTest extends TaoPhpUnitTestRunner {
      * @author Lionel Lecaque, lionel@taotesting.com
      */
 	public function testGetGroups(){
-	    $groupClass = GroupsService::singleton()->getRootClass();
+	    $groupClass = new GroupsService();
+            $groupClass = $groupClass->getRootClass();
 	    $this->assertTrue($this->groupsService->isGroupClass($groupClass));
 	     
 	    $subject = $this->subjectsService->createInstance($this->subjectsService->getRootClass(),'testSubject');


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8629

All classes extend the class tao_models_classes_ClassService are unit testable and now extend OntologyClassService class

__construct() methods of the classes are empty

All classes directly or indirectly extending tao_models_classes_ClassService do not have a custom constructor

The behaviour of the modified classes remains unchanged
The TAO platform still continue to behave as it was