### PR TITLE
TAO-8697 - Replace Calls of singleton method by ServiceManager calls

### DIFF
--- a/config/default/Groups.conf.php
+++ b/config/default/Groups.conf.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Default config header created during install
+ */
+
+return new oat\taoGroups\models\GroupsService();

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return array(
     'label' => 'Groups core extension',
     'description' => 'TAO Groups extension',
     'license' => 'GPL-2.0',
-    'version' => '6.1.0',
+    'version' => '6.1.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(
         'taoTestTaker' => '>=4.0.0',

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -40,6 +40,8 @@ use oat\oatbox\user\User;
 class GroupsService
     extends tao_models_classes_ClassService
 {
+    const SERVICE_ID = 'taoGroups/Groups';
+
     const CLASS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#Group';
 
     const PROPERTY_MEMBERS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#member';

--- a/models/update/Updater.php
+++ b/models/update/Updater.php
@@ -28,6 +28,7 @@ use oat\tao\model\accessControl\func\AclProxy;
 use oat\tao\model\accessControl\func\AccessRule;
 use oat\tao\model\user\TaoRoles;
 use oat\taoGroups\controller\Api;
+
 /**
  * Service methods to manage the Groups business models using the RDF API.
  *
@@ -77,6 +78,12 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('3.0.1');
         }
 
-        $this->skip('3.0.1','6.1.0');
+        $this->skip('3.0.1','6.1.1');
+
+        if ($this->isVersion('6.1.1')) {
+            $groupsService = new GroupsService();
+            $this->getServiceManager()->register(GroupsService::SERVICE_ID, $groupsService);
+            $this->setVersion('6.1.2');
+        }
     }
 }

--- a/test/integration/GroupsTest.php
+++ b/test/integration/GroupsTest.php
@@ -30,6 +30,7 @@ use \core_kernel_classes_Resource;
 use \core_kernel_classes_Class;
 use \core_kernel_classes_Property;
 use oat\tao\test\TaoPhpUnitTestRunner;
+use oat\oatbox\service\ServiceManager;
 
 
 
@@ -41,40 +42,43 @@ use oat\tao\test\TaoPhpUnitTestRunner;
  
  */
 class GroupsTest extends TaoPhpUnitTestRunner {
-	
-	/**
-	 * @var GroupsService
-	 */
-	protected $groupsService = null;
-	
-	protected $subjectsService = null;
 
-	/**
-	 * tests initialization
-	 */
-	public function setUp(){
+    /**
+     * @var GroupsService
+     */
+    protected $groupsService = null;
+
+    protected $subjectsService = null;
+
+    /**
+     * tests initialization
+     */
+    public function setUp()
+    {
         TaoPhpUnitTestRunner::initTest();
-		$this->subjectsService = TestTakerService::singleton();
-		$this->groupsService = GroupsService::singleton();
-	}
+        $this->subjectsService = $this->getServiceLocator()->get('TestTakerService');
+        $this->groupsService = $this->getServiceLocator()->get(GroupsService::SERVICE_ID);
+    }
 
-	/**
-	 * Test the user service implementation
-	 * @see tao_models_classes_ServiceFactory::get
-	 * @see oat\taoGroups\models\GroupsService::__construct
-	 */
-	public function testService(){
-		$this->assertIsA($this->subjectsService, '\tao_models_classes_Service');
-		$this->assertIsA($this->groupsService, 'oat\taoGroups\models\GroupsService');
-	}
+    /**
+     * Test the user service implementation
+     * @see tao_models_classes_ServiceFactory::get
+     * @see oat\taoGroups\models\GroupsService::__construct
+     */
+    public function testService()
+    {
+        $this->assertIsA($this->subjectsService, '\tao_models_classes_Service');
+        $this->assertIsA($this->groupsService, 'oat\taoGroups\models\GroupsService');
+    }
 
     /**
 	 * @return \core_kernel_classes_Class|null
      */
-    public function testGroup() {
-		$groupClass = $this->groupsService->getRootClass();
-		$this->assertIsA($groupClass, 'core_kernel_classes_Class');
-		$this->assertEquals(GroupsService::CLASS_URI, $groupClass->getUri());
+    public function testGroup()
+    {
+        $groupClass = $this->groupsService->getRootClass();
+        $this->assertIsA($groupClass, 'core_kernel_classes_Class');
+        $this->assertEquals(GroupsService::CLASS_URI, $groupClass->getUri());
 
         return $groupClass;
     }
@@ -84,11 +88,12 @@ class GroupsTest extends TaoPhpUnitTestRunner {
      * @param $group
      * @return \core_kernel_classes_Class
      */
-    public function testSubGroup($groupClass) {
-		$subGroupLabel = 'subGroup class';
-		$subGroup = $this->groupsService->createSubClass($groupClass, $subGroupLabel);
-		$this->assertIsA($subGroup, 'core_kernel_classes_Class');
-		$this->assertEquals($subGroupLabel, $subGroup->getLabel());
+    public function testSubGroup($groupClass)
+    {
+        $subGroupLabel = 'subGroup class';
+        $subGroup = $this->groupsService->createSubClass($groupClass, $subGroupLabel);
+        $this->assertIsA($subGroup, 'core_kernel_classes_Class');
+        $this->assertEquals($subGroupLabel, $subGroup->getLabel());
 
         $this->assertTrue($this->groupsService->isGroupClass($subGroup));
 
@@ -101,11 +106,12 @@ class GroupsTest extends TaoPhpUnitTestRunner {
      * @param $group
      * @return \core_kernel_classes_Resource
      */
-    public function testGroupInstance($groupClass) {
-		$groupInstanceLabel = 'group instance';
-		$groupInstance = $this->groupsService->createInstance($groupClass, $groupInstanceLabel);
-		$this->assertIsA($groupInstance, 'core_kernel_classes_Resource');
-		$this->assertEquals($groupInstanceLabel, $groupInstance->getLabel());
+    public function testGroupInstance($groupClass)
+    {
+        $groupInstanceLabel = 'group instance';
+        $groupInstance = $this->groupsService->createInstance($groupClass, $groupInstanceLabel);
+        $this->assertIsA($groupInstance, 'core_kernel_classes_Resource');
+        $this->assertEquals($groupInstanceLabel, $groupInstance->getLabel());
 
         return $groupInstance;
     }
@@ -115,18 +121,19 @@ class GroupsTest extends TaoPhpUnitTestRunner {
      * @param $subGroup
      * @return \core_kernel_classes_Class
      */
-    public function testSubGroupInstance($subGroupClass) {
-		$subGroupInstanceLabel = 'subGroup instance';
-		$subGroupInstance = $this->groupsService->createInstance($subGroupClass);
-		
-		$subGroupInstance->removePropertyValues(new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL));
-		$subGroupInstance->setLabel($subGroupInstanceLabel);
-		$this->assertIsA($subGroupInstance, 'core_kernel_classes_Resource');
-		$this->assertEquals($subGroupInstanceLabel, $subGroupInstance->getLabel());
-		
-		$subGroupInstanceLabel2 = 'my sub group instance';
-		$subGroupInstance->setLabel($subGroupInstanceLabel2);
-		$this->assertEquals($subGroupInstanceLabel2, $subGroupInstance->getLabel());
+    public function testSubGroupInstance($subGroupClass)
+    {
+        $subGroupInstanceLabel = 'subGroup instance';
+        $subGroupInstance = $this->groupsService->createInstance($subGroupClass);
+
+        $subGroupInstance->removePropertyValues(new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL));
+        $subGroupInstance->setLabel($subGroupInstanceLabel);
+        $this->assertIsA($subGroupInstance, 'core_kernel_classes_Resource');
+        $this->assertEquals($subGroupInstanceLabel, $subGroupInstance->getLabel());
+
+        $subGroupInstanceLabel2 = 'my sub group instance';
+        $subGroupInstance->setLabel($subGroupInstanceLabel2);
+        $this->assertEquals($subGroupInstanceLabel2, $subGroupInstance->getLabel());
 
         return $subGroupInstance;
     }
@@ -135,63 +142,67 @@ class GroupsTest extends TaoPhpUnitTestRunner {
      * @depends testGroupInstance
      * @param $groupInstance
      */
-    public function testDeleteGroupInstance($groupInstance) {
-		$this->assertTrue($groupInstance->delete());
+    public function testDeleteGroupInstance($groupInstance)
+    {
+        $this->assertTrue($groupInstance->delete());
     }
 
     /**
      * @depends testSubGroupInstance
      * @param $subGroupInstance
      */
-    public function testDeleteSubGroupInstance($subGroupInstance) {
-		$this->assertTrue($subGroupInstance->delete());
+    public function testDeleteSubGroupInstance($subGroupInstance)
+    {
+        $this->assertTrue($subGroupInstance->delete());
     }
 
     /**
      * @depends testSubGroup
      * @param $subGroup
      */
-    public function testDeleteSubGroupClass($subGroup) {
-		$this->assertTrue($subGroup->delete());
+    public function testDeleteSubGroupClass($subGroup)
+    {
+        $this->assertTrue($subGroup->delete());
     }
 
     /**
      * 
      * @author Lionel Lecaque, lionel@taotesting.com
      */
-	public function testGetGroups(){
-	    $groupClass = GroupsService::singleton()->getRootClass();
-	    $this->assertTrue($this->groupsService->isGroupClass($groupClass));
-	     
-	    $subject = $this->subjectsService->createInstance($this->subjectsService->getRootClass(),'testSubject');
-	    $oneGroup = $groupClass->createInstance('testGroupInstance');
-	    
-	    $this->groupsService->addUser($subject->getUri(), $oneGroup);
-	    $oneGroup2 = $groupClass->createInstance('testGroupInstance2');
-	    
-	    $subclass = $groupClass->createSubClass('testGroupSubclass');
-	    $oneGroup3 = $subclass->createInstance('testSubGroupInstance');
-	    $this->groupsService->addUser($subject->getUri(), $oneGroup3);
-	    
-	    $generisUser = new \core_kernel_users_GenerisUser($subject);
-	    $groups = $this->groupsService->getGroups($generisUser);
-	    
-	    $this->assertTrue(is_array($groups));
-	    $this->assertTrue(count($groups) == 2);
-	    array_walk($groups, function (&$group) {
-	    	$group = $group->getUri();
-	    });
-	    $this->assertContains($oneGroup->getUri(), $groups);
-	    $this->assertNotContains($oneGroup2->getUri(), $groups);
-	    $this->assertContains($oneGroup3->getUri(), $groups);
-	    
-	    $this->assertTrue($this->groupsService->deleteGroup($oneGroup));
-	    $this->assertTrue($this->groupsService->deleteGroup($oneGroup2));
-	    $this->assertTrue($this->groupsService->deleteGroup($oneGroup3));
-	    
-	    $this->assertTrue($this->groupsService->deleteClass($subclass));
+    public function testGetGroups()
+    {
+        $groupClass = $this->groupsService->getRootClass();
+        $this->assertTrue($this->groupsService->isGroupClass($groupClass));
 
-	    $subject->delete();
-	}
+        $subject = $this->subjectsService->createInstance($this->subjectsService->getRootClass(),'testSubject');
+        $oneGroup = $groupClass->createInstance('testGroupInstance');
+
+        $this->groupsService->addUser($subject->getUri(), $oneGroup);
+        $oneGroup2 = $groupClass->createInstance('testGroupInstance2');
+
+        $subclass = $groupClass->createSubClass('testGroupSubclass');
+        $oneGroup3 = $subclass->createInstance('testSubGroupInstance');
+        $this->groupsService->addUser($subject->getUri(), $oneGroup3);
+
+        $generisUser = new \core_kernel_users_GenerisUser($subject);
+        $groups = $this->groupsService->getGroups($generisUser);
+
+        $this->assertTrue(is_array($groups));
+        $this->assertTrue(count($groups) == 2);
+        array_walk($groups, function (&$group) {
+            $group = $group->getUri();
+        });
+        $this->assertContains($oneGroup->getUri(), $groups);
+        $this->assertNotContains($oneGroup2->getUri(), $groups);
+        $this->assertContains($oneGroup3->getUri(), $groups);
+
+        $this->assertTrue($this->groupsService->deleteGroup($oneGroup));
+        $this->assertTrue($this->groupsService->deleteGroup($oneGroup2));
+        $this->assertTrue($this->groupsService->deleteGroup($oneGroup3));
+
+        $this->assertTrue($this->groupsService->deleteClass($subclass));
+
+        $subject->delete();
+    }
 	
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8697
Replace Calls of singleton method by ServiceManager calls

Classes which are extending the OntologyClass  ConfigurableService,  are retrieved by using the ServiceManager::get() method instead of calling the deprecated singleton method.
