### PR TITLE
feat: Copy assigned test takers when cloning groups

### DIFF
--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -167,7 +167,7 @@ class GroupsService extends OntologyClassService
     }
 
     /**
-     * Duplicates a Group, copying associations for former  Test Takers and
+     * Duplicates a Group, copying associations for former Test Takers and
      * Deliveries to the new group.
      *
      * Test takers assigned to the group are not copied by the parent class

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -26,7 +26,6 @@
 
 namespace oat\taoGroups\models;
 
-use oat\generis\model\data\Ontology;
 use oat\tao\model\TaoOntology;
 use oat\taoTestTaker\models\TestTakerService;
 use oat\oatbox\user\User;
@@ -51,21 +50,7 @@ class GroupsService extends OntologyClassService
 
     public const PROPERTY_MEMBERS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#member';
 
-    private TestTakerService $testTakerService;
-
-    public function __construct(
-        $options = [],
-        ?TestTakerService $testTakerService = null,
-        ?Ontology $ontology = null
-    ) {
-        parent::__construct($options);
-
-        $this->testTakerService = $testTakerService ?? TestTakerService::singleton();
-
-        if ($ontology instanceof Ontology) {
-            $this->setModel($ontology);
-        }
-    }
+    private ?TestTakerService $testTakerService = null;
 
     /**
      * Returns the group top level class.
@@ -112,7 +97,7 @@ class GroupsService extends OntologyClassService
      */
     public function getUsers(string $groupUri): array
     {
-        return $this->testTakerService->getRootClass()->searchInstances(
+        return $this->getTestTakerRootClass()->searchInstances(
             [self::PROPERTY_MEMBERS_URI => $groupUri],
             ['recursive' => true, 'like' => false]
         );
@@ -163,5 +148,20 @@ class GroupsService extends OntologyClassService
         }
 
         return $newGroup;
+    }
+
+    private function getTestTakerRootClass(): core_kernel_classes_Class
+    {
+        return $this->getTestTakerService()->getRootClass();
+    }
+
+    private function getTestTakerService(): TestTakerService
+    {
+        return $this->testTakerService ?? TestTakerService::singleton();
+    }
+
+    public function setTestTakerService(TestTakerService $service): void
+    {
+        $this->testTakerService = $service;
     }
 }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -130,7 +130,7 @@ class GroupsService extends OntologyClassService
      */
     public function getUsers(string $groupUri): array
     {
-        return $this->getTestTakerRootClass()->searchInstances(
+        return $this->testTakerService->getRootClass()->searchInstances(
             [self::PROPERTY_MEMBERS_URI => $groupUri],
             ['recursive' => true, 'like' => false]
         );
@@ -194,10 +194,5 @@ class GroupsService extends OntologyClassService
         }
 
         return $newGroup;
-    }
-
-    private function getTestTakerRootClass(): core_kernel_classes_Class
-    {
-        return $this->testTakerService->getRootClass();
     }
 }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -154,7 +154,7 @@ class GroupsService extends OntologyClassService
         return $newGroup;
     }
 
-    protected function getTestTakerService(): TestTakerService
+    public function getTestTakerService(): TestTakerService
     {
         return $this->getServiceManager()->getContainer()->get(TestTakerService::class);
     }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -1,4 +1,4 @@
-<?php // @codingStandardsIgnoreStart
+<?php
 
 /**
  * This program is free software; you can redistribute it and/or
@@ -15,13 +15,14 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2002-2008 (original work) Public Research Centre Henri Tudor & University of Luxembourg (under the project TAO & TAO2);
- *               2008-2010 (update and modification) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
- *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
+ * Copyright (c) 2002-2008 (original work) Public Research Centre Henri Tudor & University of Luxembourg
+ *                         (under the project TAO & TAO2);
+ *               2008-2010 (update and modification) Deutsche Institut für Internationale Pädagogische Forschung
+ *                         (under the project TAO-TRANSFER);
+ *               2009-2012 (update and modification) Public Research Centre Henri Tudor
+ *                         (under the project TAO-SUSTAIN & TAO-DEV);
  *               2013-2023 (update and modification) Open Assessment Technologies SA
  */
-
-// @codingStandardsIgnoreEnd
 
 namespace oat\taoGroups\models;
 

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -40,8 +40,9 @@ use League\Flysystem\FileExistsException;
 /**
  * Service methods to manage the Groups business models using the RDF API.
  *
- * @access public
  * @author Joel Bout, <joel.bout@tudor.lu>
+ *
+ * @access public
  * @package taoGroups
  */
 class GroupsService extends OntologyClassService
@@ -67,37 +68,25 @@ class GroupsService extends OntologyClassService
     }
 
     /**
-     * Return the group top level class
-     *
-     * @access public
-     * @author Joel Bout, <joel.bout@tudor.lu>
-     * @return core_kernel_classes_Class
+     * Returns the group top level class.
      */
-    public function getRootClass()
+    public function getRootClass(): core_kernel_classes_Class
     {
         return $this->getClass(self::CLASS_URI);
     }
 
     /**
-     * Delete a group instance
-     *
-     * @access public
-     * @param core_kernel_classes_Resource $group
-     * @return boolean
-     * @author Joel Bout, <joel.bout@tudor.lu>
+     * Deletes a group instance.
      */
-    public function deleteGroup(core_kernel_classes_Resource $group)
+    public function deleteGroup(core_kernel_classes_Resource $group): bool
     {
         return $group !== null && $group->delete(true);
     }
 
     /**
-     * Check if the Class in parameter is a subclass of the Group Class
-     *
-     * @author Joel Bout, <joel.bout@tudor.lu>
-     * @return boolean
+     * Check if a given class is a subclass of the Group root class.
      */
-    public function isGroupClass(core_kernel_classes_Class $clazz)
+    public function isGroupClass(core_kernel_classes_Class $clazz): bool
     {
         return $clazz->equals($this->getRootClass())
             || $clazz->isSubClassOf($this->getRootClass());
@@ -106,10 +95,9 @@ class GroupsService extends OntologyClassService
     /**
      * Get the groups of a user.
      *
-     * @author Joel Bout, <joel.bout@tudor.lu>
-     * @return core_kernel_classes_Resource[] resources of group
+     * @return core_kernel_classes_Resource[] Group resources
      */
-    public function getGroups(User $user)
+    public function getGroups(User $user): array
     {
         return array_map(
             function (string $group): core_kernel_classes_Resource {
@@ -120,9 +108,9 @@ class GroupsService extends OntologyClassService
     }
 
     /**
-     * Gets the users of a group
+     * Gets the users of a group.
      *
-     * @return core_kernel_classes_Resource[] resources of users
+     * @return core_kernel_classes_Resource[] User resources
      */
     public function getUsers(string $groupUri): array
     {
@@ -133,13 +121,9 @@ class GroupsService extends OntologyClassService
     }
 
     /**
-     * Add a User to a Group
-     *
-     * @param string $userUri
-     * @param core_kernel_classes_Resource $group
-     * @return boolean
+     * Adds a user to a Group.
      */
-    public function addUser($userUri, core_kernel_classes_Resource $group)
+    public function addUser(string $userUri, core_kernel_classes_Resource $group): bool
     {
         return $this->getModel()->getResource($userUri)->setPropertyValue(
             $this->getModel()->getProperty(self::PROPERTY_MEMBERS_URI),
@@ -148,13 +132,9 @@ class GroupsService extends OntologyClassService
     }
 
     /**
-     * Remove a User from a Group
-     *
-     * @param string $userUri
-     * @param core_kernel_classes_Resource $group
-     * @return boolean
+     * Removes a user from a Group.
      */
-    public function removeUser($userUri, core_kernel_classes_Resource $group)
+    public function removeUser(string $userUri, core_kernel_classes_Resource $group): bool
     {
         return $this->getModel()->getResource($userUri)->removePropertyValue(
             $this->getModel()->getProperty(self::PROPERTY_MEMBERS_URI),
@@ -163,28 +143,23 @@ class GroupsService extends OntologyClassService
     }
 
     /**
-     * Duplicates a Group, copying associations for former Test Takers and
-     * Deliveries to the new group.
-     *
-     * Test takers assigned to the group are not copied by the parent class
-     * method (but deliveries assigned to the group are), so we need to assign
-     * them here to the new group.
-     *
-     * @param core_kernel_classes_Resource $instance Group being cloned
-     * @param ?core_kernel_classes_Class $class Class to create the duplicate in
+     * Creates a duplicate of the given group instance into the given class,
+     * copying associations for former Test Takers and Deliveries to the new group.
      *
      * @throws common_Exception
      * @throws common_exception_Error
      * @throws FileExistsException
-     *
-     * @return core_kernel_classes_Resource
      */
     public function cloneInstance(
         core_kernel_classes_Resource $instance,
         core_kernel_classes_Class $class = null
-    ) {
+    ): core_kernel_classes_Resource {
         $newGroup = parent::cloneInstance($instance, $class);
 
+        // Test takers assigned to the group are not copied by the parent class
+        // method (but deliveries assigned to the group are), so we need to
+        // assign them here to the new group.
+        //
         foreach ($this->getUsers($instance->getUri()) as $user) {
             $this->addUser($user->getUri(), $newGroup);
         }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -127,6 +127,8 @@ class GroupsService extends OntologyClassService
      */
     public function addUser($userUri, core_kernel_classes_Resource $group)
     {
+        // @fixme Instantiating core_kernel_classes_Resource directly is not testable,
+        //        would need to pass an Ontology(mock) to be used to retrieve resources
         $user = new core_kernel_classes_Resource($userUri);
         return $user->setPropertyValue(new core_kernel_classes_Property(self::PROPERTY_MEMBERS_URI), $group);
     }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -97,7 +97,7 @@ class GroupsService extends OntologyClassService
      */
     public function getUsers(string $groupUri): array
     {
-        return $this->getTestTakerRootClass()->searchInstances(
+        return $this->getTestTakerService()->getRootClass()->searchInstances(
             [self::PROPERTY_MEMBERS_URI => $groupUri],
             ['recursive' => true, 'like' => false]
         );
@@ -148,11 +148,6 @@ class GroupsService extends OntologyClassService
         }
 
         return $newGroup;
-    }
-
-    private function getTestTakerRootClass(): core_kernel_classes_Class
-    {
-        return $this->getTestTakerService()->getRootClass();
     }
 
     private function getTestTakerService(): TestTakerService

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -100,9 +100,7 @@ class GroupsService extends OntologyClassService
     public function getGroups(User $user): array
     {
         return array_map(
-            function (string $group): core_kernel_classes_Resource {
-                return $this->getModel()->getResource($group);
-            },
+            fn (string $group): core_kernel_classes_Resource => $this->getModel()->getResource($group),
             $user->getPropertyValues(self::PROPERTY_MEMBERS_URI)
         );
     }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -154,7 +154,7 @@ class GroupsService extends OntologyClassService
         return $newGroup;
     }
 
-    public function getTestTakerService(): TestTakerService
+    private function getTestTakerService(): TestTakerService
     {
         return $this->getServiceManager()->getContainer()->get(TestTakerService::class);
     }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -125,7 +125,13 @@ class GroupsService extends OntologyClassService
 
     /**
      * Creates a duplicate of the given group instance into the given class,
-     * copying associations for former Test Takers and Deliveries to the new group.
+     * copying associations for former Test Takers and Deliveries to the new
+     * group.
+     *
+     * Test takers assigned to the group are not copied by the parent class
+     * method (but deliveries assigned to the group are) so, after the parent
+     * method has copied the former relations pointing to deliveries, this
+     * method assigns all test takers from the former group to the new one.
      *
      * @throws common_Exception
      * @throws common_exception_Error
@@ -137,10 +143,6 @@ class GroupsService extends OntologyClassService
     ): core_kernel_classes_Resource {
         $newGroup = parent::cloneInstance($instance, $class);
 
-        // Test takers assigned to the group are not copied by the parent class
-        // method (but deliveries assigned to the group are), so we need to
-        // assign them here to the new group.
-        //
         foreach ($this->getUsers($instance->getUri()) as $user) {
             $this->addUser($user->getUri(), $newGroup);
         }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -26,6 +26,7 @@
 
 namespace oat\taoGroups\models;
 
+use oat\generis\model\data\Ontology;
 use oat\taoTestTaker\models\TestTakerService;
 use oat\oatbox\user\User;
 use oat\tao\model\OntologyClassService;
@@ -48,7 +49,21 @@ class GroupsService extends OntologyClassService
 
     public const PROPERTY_MEMBERS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#member';
 
-    private ?TestTakerService $testTakerService = null;
+    private TestTakerService $testTakerService;
+
+    public function __construct(
+        $options = [],
+        ?TestTakerService $testTakerService = null,
+        ?Ontology $ontology = null
+    ) {
+        parent::__construct($options);
+
+        $this->testTakerService = $testTakerService ?? TestTakerService::singleton();
+
+        if ($ontology instanceof Ontology) {
+            $this->setModel($ontology);
+        }
+    }
 
     /**
      * Return the group top level class
@@ -183,16 +198,6 @@ class GroupsService extends OntologyClassService
 
     private function getTestTakerRootClass(): core_kernel_classes_Class
     {
-        return $this->getTestTakerService()->getRootClass();
-    }
-
-    private function getTestTakerService(): TestTakerService
-    {
-        return $this->testTakerService ?? TestTakerService::singleton();
-    }
-
-    public function setTestTakerService(TestTakerService $service): void
-    {
-        $this->testTakerService = $service;
+        return $this->testTakerService->getRootClass();
     }
 }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -93,8 +93,12 @@ class GroupsService extends OntologyClassService
      *
      * @return core_kernel_classes_Resource[] User resources
      */
-    public function getUsers(string $groupUri): array
+    public function getUsers(?string $groupUri): array
     {
+        if (empty($groupUri)) {
+            return [];
+        }
+
         return $this->getTestTakerService()->getRootClass()->searchInstances(
             [self::PROPERTY_MEMBERS_URI => $groupUri],
             ['recursive' => true, 'like' => false]

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -1,4 +1,4 @@
-<?php
+<?php // @codingStandardsIgnoreStart
 
 /**
  * This program is free software; you can redistribute it and/or
@@ -21,6 +21,8 @@
  *               2013-2023 (update and modification) Open Assessment Technologies SA
  */
 
+// @codingStandardsIgnoreEnd
+
 namespace oat\taoGroups\models;
 
 use oat\taoTestTaker\models\TestTakerService;
@@ -41,9 +43,9 @@ use League\Flysystem\FileExistsException;
  */
 class GroupsService extends OntologyClassService
 {
-    const CLASS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#Group';
+    public const CLASS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#Group';
 
-    const PROPERTY_MEMBERS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#member';
+    public const PROPERTY_MEMBERS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#member';
 
     private ?TestTakerService $testTakerService = null;
 
@@ -97,13 +99,13 @@ class GroupsService extends OntologyClassService
     public function getGroups(User $user)
     {
         return array_map(
-            function(string $group): core_kernel_classes_Resource {
+            function (string $group): core_kernel_classes_Resource {
                 return $this->getModel()->getResource($group);
             },
             $user->getPropertyValues(self::PROPERTY_MEMBERS_URI)
         );
     }
-    
+
     /**
      * Gets the users of a group
      *
@@ -117,7 +119,7 @@ class GroupsService extends OntologyClassService
             ['recursive' => true, 'like' => false]
         );
     }
-    
+
     /**
      * Add a User to a Group
      *
@@ -132,7 +134,7 @@ class GroupsService extends OntologyClassService
             $group
         );
     }
-    
+
     /**
      * Remove a User from a Group
      *

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -50,8 +50,6 @@ class GroupsService extends OntologyClassService
 
     public const PROPERTY_MEMBERS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#member';
 
-    private ?TestTakerService $testTakerService = null;
-
     /**
      * Returns the group top level class.
      */
@@ -150,13 +148,8 @@ class GroupsService extends OntologyClassService
         return $newGroup;
     }
 
-    private function getTestTakerService(): TestTakerService
+    protected function getTestTakerService(): TestTakerService
     {
-        return $this->testTakerService ?? TestTakerService::singleton();
-    }
-
-    public function setTestTakerService(TestTakerService $service): void
-    {
-        $this->testTakerService = $service;
+        return $this->getServiceManager()->getContainer()->get(TestTakerService::class);
     }
 }

--- a/models/GroupsService.php
+++ b/models/GroupsService.php
@@ -27,6 +27,7 @@
 namespace oat\taoGroups\models;
 
 use oat\generis\model\data\Ontology;
+use oat\tao\model\TaoOntology;
 use oat\taoTestTaker\models\TestTakerService;
 use oat\oatbox\user\User;
 use oat\tao\model\OntologyClassService;
@@ -45,7 +46,7 @@ use League\Flysystem\FileExistsException;
  */
 class GroupsService extends OntologyClassService
 {
-    public const CLASS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#Group';
+    public const CLASS_URI = TaoOntology::CLASS_URI_GROUP;
 
     public const PROPERTY_MEMBERS_URI = 'http://www.tao.lu/Ontologies/TAOGroup.rdf#member';
 
@@ -93,9 +94,7 @@ class GroupsService extends OntologyClassService
     /**
      * Check if the Class in parameter is a subclass of the Group Class
      *
-     * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  core_kernel_classes_Class $clazz
      * @return boolean
      */
     public function isGroupClass(core_kernel_classes_Class $clazz)
@@ -105,12 +104,10 @@ class GroupsService extends OntologyClassService
     }
 
     /**
-     * Get the groups of a user
+     * Get the groups of a user.
      *
-     * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  User $user
-     * @return array resources of group
+     * @return core_kernel_classes_Resource[] resources of group
      */
     public function getGroups(User $user)
     {
@@ -125,7 +122,6 @@ class GroupsService extends OntologyClassService
     /**
      * Gets the users of a group
      *
-     * @param string $groupUri
      * @return core_kernel_classes_Resource[] resources of users
      */
     public function getUsers(string $groupUri): array

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -135,6 +135,17 @@ class GroupServiceTest extends TestCase
         $this->assertEquals($this->userMock, $users[0]);
     }
 
+    public function testGetUsersForNullGroupUri(): void
+    {
+        $this->testTakerServiceMock
+            ->expects($this->never())
+            ->method('getRootClass');
+
+        $users = $this->sut->getUsers(null);
+
+        $this->assertEmpty($users);
+    }
+
     /**
      * @depends testGetUsers
      */

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -1,0 +1,6 @@
+<?php
+
+class GroupServiceTest
+{
+
+}

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -25,6 +25,7 @@ namespace oat\taoGroups\test\unit\model;
 use oat\generis\model\data\Ontology;
 use oat\generis\model\OntologyRdfs;
 use oat\generis\test\ServiceManagerMockTrait;
+use oat\oatbox\service\ServiceManager;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\User;
 use oat\taoGroups\models\GroupsService;
@@ -66,8 +67,13 @@ class GroupServiceTest extends TestCase
         $this->group1Mock->method('getUri')->willReturn('http://example.com/group1');
         $this->group2Mock->method('getUri')->willReturn('http://example.com/group2');
 
+        ServiceManager::setServiceManager(
+            $this->getServiceManagerMock([
+                TestTakerService::class => $this->testTakerServiceMock,
+            ])
+        );
+
         $this->sut = new GroupsService();
-        $this->sut->setTestTakerService($this->testTakerServiceMock);
         $this->sut->setModel($this->ontology);
     }
 

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -66,11 +66,9 @@ class GroupServiceTest extends TestCase
         $this->group1Mock->method('getUri')->willReturn('http://example.com/group1');
         $this->group2Mock->method('getUri')->willReturn('http://example.com/group2');
 
-        $this->sut = new GroupsService(
-            [],
-            $this->testTakerServiceMock,
-            $this->ontology
-        );
+        $this->sut = new GroupsService();
+        $this->sut->setTestTakerService($this->testTakerServiceMock);
+        $this->sut->setModel($this->ontology);
     }
 
     public function testGetGroups(): void
@@ -221,7 +219,8 @@ class GroupServiceTest extends TestCase
         $this->userMock
             ->expects($this->once())
             ->method('setPropertyValue')
-            ->with($membersProperty, $newGroupMock);
+            ->with($membersProperty, $newGroupMock)
+            ->willReturn(true);
 
         $result = $this->sut->cloneInstance($groupMock, $classMock);
         $this->assertSame($newGroupMock, $result);

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -26,6 +26,7 @@ use core_kernel_classes_Class;
 use core_kernel_classes_Resource;
 use oat\oatbox\log\LoggerService;
 use oat\oatbox\service\ServiceManager;
+use oat\oatbox\session\SessionService;
 use oat\oatbox\user\User;
 use oat\tao\model\taskQueue\QueueDispatcher;
 use oat\taoGroups\models\GroupsService;
@@ -96,8 +97,76 @@ class GroupServiceTest extends TestCase
         $this->assertEquals($this->userMock, $users[0]);
     }
 
+    /**
+     * @depends testGetUsers
+     */
     public function testCloneInstance(): void
     {
-        $this->markTestIncomplete('TO-DO');
+        $classMock = $this->createMock(core_kernel_classes_Class::class);
+        $groupMock = $this->createMock(core_kernel_classes_Resource::class);
+        $newGroupMock = $this->createMock(core_kernel_classes_Resource::class);
+
+        $classMock
+            ->expects($this->once())
+            ->method('createInstance')
+            ->with($this->anything())
+            ->willReturn($newGroupMock);
+
+        $classMock
+            ->method('getLabel')
+            ->willReturn('Class Label');
+
+        $classMock
+            ->method('getInstances')
+            ->willReturn([]);
+
+        $classMock
+            ->method('getProperties')
+            ->with(true)
+            ->willReturn([]);
+
+        $newGroupMock
+            ->expects($this->once())
+            ->method('setLabel')
+            ->with($this->anything());
+
+        $ttRootClassMock = $this->createMock(core_kernel_classes_Class::class);
+        $ttRootClassMock
+            ->expects($this->once())
+            ->method('searchInstances')
+            ->with(
+                [GroupsService::PROPERTY_MEMBERS_URI => 'http://example.com/group1'],
+                ['recursive' => true, 'like' => false]
+            )
+            ->willReturn([$this->userMock]);
+
+        $this->testTakerServiceMock
+            ->expects($this->once())
+            ->method('getRootClass')
+            ->willReturn($ttRootClassMock);
+
+
+        // @todo Mock the getDataLanguage() call from GenerisServiceTrait
+        //       (called by GenerisServiceTrait::cloneInstance()).
+        /*
+         * 1) oat\taoDacSimple\test\GroupServiceTest::testCloneInstance
+         *
+         *      Error: Call to a member function get() on null
+         *
+         *      tao/models/classes/GenerisServiceTrait.php:109
+         *      tao/models/classes/GenerisServiceTrait.php:83
+         *      tao/models/classes/GenerisServiceTrait.php:182
+         *      taoGroups/models/GroupsService.php:168
+         *      taoGroups/test/unit/model/GroupServiceTest.php:151
+         */
+        $result = $this->sut->cloneInstance($groupMock, $classMock);
+        $this->assertSame($newGroupMock, $result);
+
+        // @todo Test if the users have been copied
+        //       (i.e. if addUser / $user->setPropertyValue() has been called
+        //        for former users in the copied group)
+
+
+        $this->markTestIncomplete('Work in Progress');
     }
 }

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -67,7 +67,7 @@ class GroupServiceTest extends TestCase
         $this->group2Mock->method('getUri')->willReturn('http://example.com/group2');
 
         $this->sut = new GroupsService(
-             [],
+            [],
             $this->testTakerServiceMock,
             $this->ontology
         );

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -1,6 +1,103 @@
 <?php
 
-class GroupServiceTest
-{
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA.
+ */
 
+declare(strict_types=1);
+
+namespace oat\taoDacSimple\test;
+
+use core_kernel_classes_Class;
+use core_kernel_classes_Resource;
+use oat\oatbox\log\LoggerService;
+use oat\oatbox\service\ServiceManager;
+use oat\oatbox\user\User;
+use oat\tao\model\taskQueue\QueueDispatcher;
+use oat\taoGroups\models\GroupsService;
+use oat\taoTestTaker\models\TestTakerService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class GroupServiceTest extends TestCase
+{
+    /** @var GroupsService */
+    private $sut;
+
+    /** @var User|MockObject */
+    private $userMock;
+
+    public function setUp(): void
+    {
+        $this->sut = new GroupsService();
+        $this->userMock = $this->createMock(User::class);
+        $this->testTakerServiceMock = $this->createMock(TestTakerService::class);
+
+        $this->sut->setTestTakerService($this->testTakerServiceMock);
+    }
+
+    public function testGetGroups(): void
+    {
+        $this->userMock
+            ->expects($this->once())
+            ->method('getPropertyValues')
+            ->with(GroupsService::PROPERTY_MEMBERS_URI)
+            ->willReturn(
+                [
+                    'http://example.com/group1',
+                    'http://example.com/group2'
+                ]
+            );
+
+        $groups = $this->sut->getGroups($this->userMock);
+
+        $this->assertContainsOnlyInstancesOf(
+            core_kernel_classes_Resource::class,
+            $groups
+        );
+        $this->assertEquals('http://example.com/group1', $groups[0]->getUri());
+        $this->assertEquals('http://example.com/group2', $groups[1]->getUri());
+    }
+
+    public function testGetUsers(): void
+    {
+        $ttRootClassMock = $this->createMock(core_kernel_classes_Class::class);
+        $ttRootClassMock
+            ->expects($this->once())
+            ->method('searchInstances')
+            ->with(
+                [GroupsService::PROPERTY_MEMBERS_URI => 'http://example.com/group1'],
+                ['recursive' => true, 'like' => false]
+            )
+            ->willReturn([$this->userMock]);
+
+        $this->testTakerServiceMock
+            ->expects($this->once())
+            ->method('getRootClass')
+            ->willReturn($ttRootClassMock);
+
+        $users = $this->sut->getUsers('http://example.com/group1');
+
+        $this->assertCount(1, $users);
+        $this->assertEquals($this->userMock, $users[0]);
+    }
+
+    public function testCloneInstance(): void
+    {
+        $this->markTestIncomplete('TO-DO');
+    }
 }

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -110,6 +110,24 @@ class GroupServiceTest extends TestCase
         $classMock = $this->createMock(core_kernel_classes_Class::class);
         $groupMock = $this->createMock(core_kernel_classes_Resource::class);
         $newGroupMock = $this->createMock(core_kernel_classes_Resource::class);
+        /*$groupMock = $this->getMockBuilder(User::class)
+            //->setMockClassName(core_kernel_classes_Resource::class)
+            ->setMethods(array_merge(get_class_methods(User::class),['getUri']))
+               // ->enableProxyingToOriginalMethods()
+
+            ->getMock();*/
+
+        $this->userMock = $this->createMock(core_kernel_classes_Resource::class);
+
+        $this->userMock
+            ->expects($this->once())
+            ->method('getUri')
+            ->willReturn('http://example.com/user1');
+
+        $this->userMock
+            ->expects($this->once())
+            ->method('setPropertyValue')
+            ->with($this->anything(), $this->anything()); // @fixme
 
         $classMock
             ->expects($this->once())
@@ -135,6 +153,11 @@ class GroupServiceTest extends TestCase
             ->method('setLabel')
             ->with($this->anything());
 
+        $groupMock
+            ->expects($this->once())
+            ->method('getUri')
+            ->willReturn('http://example.com/group1');
+
         $ttRootClassMock = $this->createMock(core_kernel_classes_Class::class);
         $ttRootClassMock
             ->expects($this->once())
@@ -158,6 +181,8 @@ class GroupServiceTest extends TestCase
                 $this->anything()
             )
             ->willReturn([]);
+
+
 
         // @todo Mock the getDataLanguage() call from GenerisServiceTrait
         //       (called by GenerisServiceTrait::cloneInstance()).

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-namespace oat\taoDacSimple\test;
+namespace oat\taoGroups\test\unit\model;
 
 use oat\generis\model\data\Ontology;
 use oat\generis\model\OntologyRdfs;

--- a/test/unit/model/GroupServiceTest.php
+++ b/test/unit/model/GroupServiceTest.php
@@ -66,9 +66,11 @@ class GroupServiceTest extends TestCase
         $this->group1Mock->method('getUri')->willReturn('http://example.com/group1');
         $this->group2Mock->method('getUri')->willReturn('http://example.com/group2');
 
-        $this->sut = new GroupsService();
-        $this->sut->setTestTakerService($this->testTakerServiceMock);
-        $this->sut->setModel($this->ontology);
+        $this->sut = new GroupsService(
+             [],
+            $this->testTakerServiceMock,
+            $this->ontology
+        );
     }
 
     public function testGetGroups(): void


### PR DESCRIPTION
**Associated Jira issue:** [AUT-270](https://oat-sa.atlassian.net/browse/AUT-270)

The controller for cloning a group calls `GroupsService::cloneInstance()` (as `GroupsService` is returned by the controller's `getClassService()` method). In turn , `GroupsService` extends from `OntoogyClassService` and directly exposes its `cloneInstance()` method. That method only takes into account properties defined as part of the class associated with the resource being copied.

For groups, deliveries are a property for the group itself (i.e. defined in the root class for groups, direction `group->delivery`), and because of that `GenerisServiceTrait::cloneInstance()` already copies them when cloning a group.

However, the group(s) a user belongs to is stored as a property associated **with the user** (with URI "http://www.tao.lu/Ontologies/TAOGroup.rdf#member", direction `user->group`).

Therefore, we need to call the pre-existing service method `getUsers()` to retrieve the users linked to the group and create the corresponding associations pointing to the cloned group as part of the call to `GroupsService`.

- [x] Fix the issue
- [x] Finish tests
- [x] Check PSR-12

[AUT-270]: https://oat-sa.atlassian.net/browse/AUT-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ