### PR TITLE
fix: use copy-to icon for quickwins design

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -49,7 +49,7 @@
                         <icon id="icon-copy"/>
                     </action>
                     <action id="group-copy-to" name="Copy To" url="/taoGroups/Groups/copyInstance" context="instance" group="tree" binding="copyTo" weight="7">
-                        <icon id="icon-copy"/>
+                        <icon id="icon-copy" alt="icon-copy-to"/>
                     </action>
                     <action id="group-move-to" name="Move To" url="/taoGroups/Groups/moveResource" context="resource" group="tree" binding="moveTo" weight="6">
                         <icon id="icon-move-item"/>

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -46,10 +46,10 @@
                         <icon id="icon-export"/>
                     </action>
                     <action id="group-duplicate" name="Duplicate" url="/taoGroups/Groups/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="8">
-                        <icon id="icon-copy"/>
+                        <icon id="icon-duplicate"/>
                     </action>
                     <action id="group-copy-to" name="Copy To" url="/taoGroups/Groups/copyInstance" context="instance" group="tree" binding="copyTo" weight="7">
-                        <icon id="icon-copy" alt="icon-copy-to"/>
+                        <icon id="icon-copy"/>
                     </action>
                     <action id="group-move-to" name="Move To" url="/taoGroups/Groups/moveResource" context="resource" group="tree" binding="moveTo" weight="6">
                         <icon id="icon-move-item"/>


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/AUT-4061

## What's Changed

- Added support of alternative icon, specifically alternative for the `Copy` icon

## How to test

- Run the app with FEATURE_FLAG_QUICK_WINS_ENABLED FF enabled
- Check Copy to icons are updated accordingly