### PR TITLE
fix: correct action bar icon order weights (AUT-4491)

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -18,13 +18,13 @@
                       />
                 </trees>
                 <actions>
-                    <action id="group-class-properties" name="Properties" url="/taoGroups/Groups/editClassLabel" group="content" context="class" weight="10">
+                    <action id="group-class-properties" name="Properties" url="/taoGroups/Groups/editClassLabel" group="content" context="class" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="group-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
+                    <action id="group-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="8">
                         <icon id="icon-property-add"/>
                     </action>
-                    <action id="group-properties" name="Properties"  url="/taoGroups/Groups/editGroup" group="content" context="instance" weight="10">
+                    <action id="group-properties" name="Properties"  url="/taoGroups/Groups/editGroup" group="content" context="instance" weight="1">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="group-class-new" name="New class" url="/taoGroups/Groups/addSubClass" context="resource" group="tree" binding="subClass" weight="10">

--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -18,46 +18,46 @@
                       />
                 </trees>
                 <actions>
-                    <action id="group-class-properties" name="Properties" url="/taoGroups/Groups/editClassLabel" group="content" context="class">
+                    <action id="group-class-properties" name="Properties" url="/taoGroups/Groups/editClassLabel" group="content" context="class" weight="10">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="group-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class">
+                    <action id="group-class-schema" name="Manage Schema" url="/tao/PropertiesAuthoring/index" group="content" context="class" weight="3">
                         <icon id="icon-property-add"/>
                     </action>
-                    <action id="group-properties" name="Properties"  url="/taoGroups/Groups/editGroup" group="content" context="instance">
+                    <action id="group-properties" name="Properties"  url="/taoGroups/Groups/editGroup" group="content" context="instance" weight="10">
                         <icon id="icon-edit"/>
                     </action>
                     <action id="group-class-new" name="New class" url="/taoGroups/Groups/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="group-delete" name="Delete" url="/taoGroups/Groups/delete" context="resource" group="tree" binding="removeNode"  weight="-1">
+                    <action id="group-delete" name="Delete" url="/taoGroups/Groups/delete" context="resource" group="tree" binding="removeNode"  weight="9">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="group-delete-all" name="Delete" url="/taoGroups/Groups/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="-2">
+                    <action id="group-delete-all" name="Delete" url="/taoGroups/Groups/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="9">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="group-move" name="Move" url="/taoGroups/Groups/moveInstance" context="instance" group="none" binding="moveNode">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="group-import" name="Import" url="/tao/Import/index" context="resource" group="tree" weight="5">
+                    <action id="group-import" name="Import" url="/tao/Import/index" context="resource" group="tree" weight="8">
                         <icon id="icon-import"/>
                     </action>
-                    <action id="group-export" name="Export" url="/tao/Export/index" context="resource" group="tree" weight="4">
+                    <action id="group-export" name="Export" url="/tao/Export/index" context="resource" group="tree" weight="7">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="group-duplicate" name="Duplicate" url="/taoGroups/Groups/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="8">
+                    <action id="group-duplicate" name="Duplicate" url="/taoGroups/Groups/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="6">
                         <icon id="icon-duplicate"/>
                     </action>
-                    <action id="group-copy-to" name="Copy To" url="/taoGroups/Groups/copyInstance" context="instance" group="tree" binding="copyTo" weight="7">
+                    <action id="group-copy-to" name="Copy To" url="/taoGroups/Groups/copyInstance" context="instance" group="tree" binding="copyTo" weight="5">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="group-move-to" name="Move To" url="/taoGroups/Groups/moveResource" context="resource" group="tree" binding="moveTo" weight="6">
+                    <action id="group-move-to" name="Move To" url="/taoGroups/Groups/moveResource" context="resource" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="group-move-all" name="Move To" url="/taoGroups/Groups/moveAll" context="resource" multiple="true" group="tree" binding="moveTo">
+                    <action id="group-move-all" name="Move To" url="/taoGroups/Groups/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="4">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="group-new" name="New Group" url="/taoGroups/Groups/addInstance" context="resource" group="tree" binding="instanciate" weight="9">
+                    <action id="group-new" name="New Group" url="/taoGroups/Groups/addInstance" context="resource" group="tree" binding="instanciate" weight="1">
                         <icon id="icon-users"/>
                     </action>
                 </actions>


### PR DESCRIPTION
# fix: correct action bar icon order weights (AUT-4491)

## Summary

- Adds missing `weight` attributes to all action definitions in `structures.xml` files across affected extensions.
- Fixes incorrect icon order in the Actions menu (all tabs) when the QuickWins design feature flag is enabled.
- Root cause: `getSortedActionsByWeight()` in `tao/helpers/Layout.php` sorts ascending by weight; weights were never consistently set when weight-based sorting was introduced in AUT-3938.

## Weight conventions applied

### Tree actions (lower = leftmost)
| Weight | Action type |
|--------|------------|
| 10 | New class |
| 9 | Delete (instance / class / all) |
| 8 | Import |
| 7 | Export / Publish |
| 6 | Duplicate |
| 5 | Copy To |
| 4 | Move To |
| 3 | Translate |
| 1 | New [entity] (primary create action) |

### Content actions
| Weight | Action type |
|--------|------------|
| 10 | Properties (instance / class) |
| 9 | Preview |
| 8 | Authoring |
| 7 | History |
| 6 | Usage |
| 5 | Item Statistics |
| 3 | Manage Schema |

## Impacted extensions

- `extension-tao-item` (taoItems)
- `extension-tao-itemqti` (taoQtiItem)
- `extension-tao-test` (taoTests)
- `extension-tao-testqti` (taoQtiTest)
- `extension-tao-group` (taoGroups)
- `extension-tao-testtaker` (taoTestTaker)
- `extension-tao-delivery-rdf` (taoDeliveryRdf)
- `extension-tao-deliver-connect` (taoDeliverConnect)
- `extension-tao-backoffice` (taoBackOffice)
- `extension-tao-outcomeui` (taoOutcomeUi)
- `extension-tao-proctoring` (taoProctoring)
- `extension-remote-proctoring` (remoteProctoring)
- `extension-tao-lti-consumer` (taoLtiConsumer)
- `extension-tao-testcenter` (taoTestCenter)
- `extension-tao-blueprints` (taoBlueprints)
- `extension-tao-mediamanager` (taoMediaManager)

## Testing

Enable the QuickWins design feature flag and verify the Actions toolbar icons appear in the correct order on all tabs (Items, Tests, Test-Takers, Groups, Deliveries, Results, Assets, Blueprints, Test Centers).

No code logic changes — XML `weight` attribute additions/corrections only.

## Related

- Jira: AUT-4491
- Introduced by: AUT-3938 (weight-based sort added to Layout.php)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized the priority ordering of actions in the groups management interface to improve navigation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->