### PR TITLE
fix: reorder tree actions for AUT-4491

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -27,37 +27,37 @@
                     <action id="group-properties" name="Properties"  url="/taoGroups/Groups/editGroup" group="content" context="instance" weight="1">
                         <icon id="icon-edit"/>
                     </action>
-                    <action id="group-class-new" name="New class" url="/taoGroups/Groups/addSubClass" context="resource" group="tree" binding="subClass" weight="10">
+                    <action id="group-class-new" name="New class" url="/taoGroups/Groups/addSubClass" context="resource" group="tree" binding="subClass" weight="1">
                         <icon id="icon-folder-open"/>
                     </action>
-                    <action id="group-delete" name="Delete" url="/taoGroups/Groups/delete" context="resource" group="tree" binding="removeNode"  weight="9">
+                    <action id="group-delete" name="Delete" url="/taoGroups/Groups/delete" context="resource" group="tree" binding="removeNode"  weight="2">
                         <icon id="icon-bin"/>
                     </action>
-                    <action id="group-delete-all" name="Delete" url="/taoGroups/Groups/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="9">
+                    <action id="group-delete-all" name="Delete" url="/taoGroups/Groups/deleteAll" context="resource" multiple="true" group="tree" binding="removeNodes" weight="2">
                         <icon id="icon-bin"/>
                     </action>
                     <action id="group-move" name="Move" url="/taoGroups/Groups/moveInstance" context="instance" group="none" binding="moveNode">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="group-import" name="Import" url="/tao/Import/index" context="resource" group="tree" weight="8">
+                    <action id="group-import" name="Import" url="/tao/Import/index" context="resource" group="tree" weight="3">
                         <icon id="icon-import"/>
                     </action>
-                    <action id="group-export" name="Export" url="/tao/Export/index" context="resource" group="tree" weight="7">
+                    <action id="group-export" name="Export" url="/tao/Export/index" context="resource" group="tree" weight="4">
                         <icon id="icon-export"/>
                     </action>
-                    <action id="group-duplicate" name="Duplicate" url="/taoGroups/Groups/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="6">
+                    <action id="group-duplicate" name="Duplicate" url="/taoGroups/Groups/cloneInstance" context="instance" group="tree" binding="duplicateNode" weight="5">
                         <icon id="icon-duplicate"/>
                     </action>
-                    <action id="group-copy-to" name="Copy To" url="/taoGroups/Groups/copyInstance" context="instance" group="tree" binding="copyTo" weight="5">
+                    <action id="group-copy-to" name="Copy To" url="/taoGroups/Groups/copyInstance" context="instance" group="tree" binding="copyTo" weight="6">
                         <icon id="icon-copy"/>
                     </action>
-                    <action id="group-move-to" name="Move To" url="/taoGroups/Groups/moveResource" context="resource" group="tree" binding="moveTo" weight="4">
+                    <action id="group-move-to" name="Move To" url="/taoGroups/Groups/moveResource" context="resource" group="tree" binding="moveTo" weight="7">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="group-move-all" name="Move To" url="/taoGroups/Groups/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="4">
+                    <action id="group-move-all" name="Move To" url="/taoGroups/Groups/moveAll" context="resource" multiple="true" group="tree" binding="moveTo" weight="7">
                         <icon id="icon-move-item"/>
                     </action>
-                    <action id="group-new" name="New Group" url="/taoGroups/Groups/addInstance" context="resource" group="tree" binding="instanciate" weight="1">
+                    <action id="group-new" name="New Group" url="/taoGroups/Groups/addInstance" context="resource" group="tree" binding="instanciate" weight="8">
                         <icon id="icon-users"/>
                     </action>
                 </actions>


### PR DESCRIPTION
## Summary

Adjust tree action weights in Groups to enforce the expected Tree Actions order for AUT-4491.

## Changes

- Updated `taoGroups/controller/structures.xml` action weights for `group="tree"`.
- Final order:
  - New class
  - Delete
  - Import
  - Export
  - Duplicate
  - Copy To
  - Move To
  - New Group

## Validation

- Open **Groups** tree and verify action order in the action bar.

## Risk

Low. XML weight-only ordering change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted the ordering of group actions in the interface for improved menu organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->